### PR TITLE
<FEAT> sse-connect API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+dump.rdb

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ repositories {
 
 dependencies {
 	// r2dbc
-	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 
 	// redis

--- a/src/main/java/com/instream/chatSync/ChatSyncApplication.java
+++ b/src/main/java/com/instream/chatSync/ChatSyncApplication.java
@@ -1,0 +1,13 @@
+package com.instream.chatSync;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ChatSyncApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ChatSyncApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/instream/chatSync/domain/chat/config/ChatConfig.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/config/ChatConfig.java
@@ -1,0 +1,44 @@
+package com.instream.chatSync.domain.chat.config;
+
+import static org.springdoc.webflux.core.fn.SpringdocRouteBuilder.route;
+import static org.springdoc.core.fn.builders.apiresponse.Builder.responseBuilder;
+import static org.springdoc.core.fn.builders.requestbody.Builder.requestBodyBuilder;
+
+import com.instream.chatSync.domain.chat.domain.dto.request.ChatConnectRequestDto;
+import com.instream.chatSync.domain.chat.handler.ChatHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.server.RequestPredicates;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class ChatConfig {
+    @Bean
+    public RouterFunction<ServerResponse> v1ChatRoutes(
+        ChatHandler chatHandler) {
+        return route().nest(RequestPredicates.path("/v1/chats"),
+            builder -> {
+                builder.add(postConnection(chatHandler));
+            },
+            ops -> ops.operationId("919")
+        ).build();
+    }
+
+        private RouterFunction<ServerResponse> postConnection(ChatHandler chatHandler) {
+            return route()
+                .POST(
+                    "/sse-connect",
+                    chatHandler::postConnection,
+                    ops -> ops.operationId("919")
+                        .requestBody(requestBodyBuilder().implementation(ChatConnectRequestDto.class).required(true))
+                        .response(responseBuilder().responseCode(HttpStatus.CREATED.name()))
+                )
+                .build();
+        }
+
+
+
+
+}

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/SubscriptionRegistry.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/SubscriptionRegistry.java
@@ -1,2 +1,25 @@
-package com.instream.chatSync.domain.chat.domain.dto;public class SubscriptionRegistry {
+package com.instream.chatSync.domain.chat.domain.dto;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SubscriptionRegistry {
+    private final ConcurrentHashMap<String, List<String>> subscriptions = new ConcurrentHashMap<>();
+
+    public void addSubscriber(String sessionId, String participantId) {
+        subscriptions.computeIfAbsent(sessionId, k -> new ArrayList<>()).add(participantId);
+    }
+
+    public void removeSubscriber(String sessionId, String participantId) {
+        if (subscriptions.containsKey(sessionId)) {
+            subscriptions.get(sessionId).remove(participantId);
+        }
+    }
+
+    public List<String> getSubscribers(String sessionId) {
+        return subscriptions.getOrDefault(sessionId, new ArrayList<>());
+    }
 }

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/SubscriptionRegistry.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/SubscriptionRegistry.java
@@ -1,0 +1,2 @@
+package com.instream.chatSync.domain.chat.domain.dto;public class SubscriptionRegistry {
+}

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/dto/ChatParticipantListDto.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/dto/ChatParticipantListDto.java
@@ -2,7 +2,7 @@ package com.instream.chatSync.domain.chat.domain.dto.dto;
 
 import java.util.List;
 
-public record ChatParticipantDto(
+public record ChatParticipantListDto(
     String sessionId,
     List<String> participantId
 ) {}

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/dto/ChatParticipantListDto.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/dto/ChatParticipantListDto.java
@@ -1,0 +1,8 @@
+package com.instream.chatSync.domain.chat.domain.dto.dto;
+
+import java.util.List;
+
+public record ChatParticipantDto(
+    String sessionId,
+    List<String> participantId
+) {}

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/request/ChatConnectRequestDto.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/request/ChatConnectRequestDto.java
@@ -1,0 +1,8 @@
+package com.instream.chatSync.domain.chat.domain.dto.request;
+
+import java.util.UUID;
+
+public record ChatConnectRequestDto(
+    String sessionId,
+    String participantId
+) {}

--- a/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
@@ -1,0 +1,30 @@
+package com.instream.chatSync.domain.chat.handler;
+
+import com.instream.chatSync.domain.chat.domain.dto.request.ChatConnectRequestDto;
+import com.instream.chatSync.domain.chat.service.ChatService;
+import com.instream.chatSync.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.chatSync.domain.error.model.exception.RestApiException;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+public class ChatHandler {
+    private final ChatService chatService;
+
+    @Autowired
+    public ChatHandler(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    public Mono<ServerResponse> postConnection(ServerRequest request) {
+        return request.bodyToMono(ChatConnectRequestDto.class)
+            .onErrorMap(throwable -> new RestApiException(CommonHttpErrorCode.BAD_REQUEST))
+            .flatMap(chatService::postConnection)
+            .then(ServerResponse.status(HttpStatus.CREATED).build());
+    }
+}

--- a/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
@@ -1,0 +1,46 @@
+package com.instream.chatSync.domain.chat.service;
+
+import com.instream.chatSync.domain.chat.domain.dto.SubscriptionRegistry;
+import com.instream.chatSync.domain.chat.domain.dto.request.ChatConnectRequestDto;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class ChatService {
+    @Autowired
+    private RedisMessageListenerContainer redisContainer;
+
+    @Autowired
+    private MessageListenerAdapter messageListener;
+
+    @Autowired
+    private SubscriptionRegistry subscriptionRegistry;
+
+    public void subscribeToSession(String sessionId, String participantId) {
+        // 구독자 추가
+        subscriptionRegistry.addSubscriber(sessionId, participantId);
+    }
+
+    public void unsubscribeFromSession(String sessionId, String participantId) {
+        // 구독자 제거
+        subscriptionRegistry.removeSubscriber(sessionId, participantId);
+    }
+
+    public List<String> getSessionSubscribers(String sessionId) {
+        // 특정 세션의 구독자 목록 조회
+        return subscriptionRegistry.getSubscribers(sessionId);
+    }
+
+    public Mono<Void> postConnection(ChatConnectRequestDto connectRequestDto) {
+        ChannelTopic topic = new ChannelTopic(connectRequestDto.sessionId());
+        this.subscribeToSession(connectRequestDto.sessionId(), connectRequestDto.participantId());
+        redisContainer.addMessageListener(messageListener, topic);
+        System.out.println(getSessionSubscribers(connectRequestDto.sessionId()));
+        return Mono.empty();
+    }
+}

--- a/src/main/java/com/instream/chatSync/domain/redis/MessagePublisher.java
+++ b/src/main/java/com/instream/chatSync/domain/redis/MessagePublisher.java
@@ -1,0 +1,5 @@
+package com.instream.chatSync.domain.redis;
+
+public interface MessagePublisher {
+    void publish(String message);
+}

--- a/src/main/java/com/instream/chatSync/domain/redis/RedisMessagePublisher.java
+++ b/src/main/java/com/instream/chatSync/domain/redis/RedisMessagePublisher.java
@@ -1,0 +1,17 @@
+package com.instream.chatSync.domain.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+
+public class RedisMessagePublisher implements MessagePublisher {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+    @Autowired
+    private ChannelTopic topic;
+
+    public void publish(String message) {
+        redisTemplate.convertAndSend(topic.getTopic(), message);
+    }
+}

--- a/src/main/java/com/instream/chatSync/domain/redis/RedisMessageSubscriber.java
+++ b/src/main/java/com/instream/chatSync/domain/redis/RedisMessageSubscriber.java
@@ -1,0 +1,18 @@
+package com.instream.chatSync.domain.redis;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisMessageSubscriber implements MessageListener {
+
+    public static List<String> messageList = new ArrayList<String>();
+
+    public void onMessage(Message message, byte[] pattern) {
+        messageList.add(message.toString());
+        System.out.println("Message received: " + message.toString());
+    }
+}

--- a/src/main/java/com/instream/chatSync/domain/redis/config/ReactiveRedisTemplateFactory.java
+++ b/src/main/java/com/instream/chatSync/domain/redis/config/ReactiveRedisTemplateFactory.java
@@ -1,0 +1,40 @@
+//package com.instream.chatSync.domain.redis.config;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import java.util.concurrent.ConcurrentHashMap;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+//import org.springframework.data.redis.core.ReactiveRedisTemplate;
+//import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+//import org.springframework.data.redis.serializer.RedisSerializationContext;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//public class ReactiveRedisTemplateFactory {
+//    private final ReactiveRedisConnectionFactory factory;
+//
+//    private final ConcurrentHashMap<Class<?>, ReactiveRedisTemplate<String, ?>> templateCache = new ConcurrentHashMap<>();
+//
+//    private final ObjectMapper objectMapper;
+//
+//    @Autowired
+//    public ReactiveRedisTemplateFactory(ReactiveRedisConnectionFactory factory, ObjectMapper objectMapper) {
+//        this.factory = factory;
+//        this.objectMapper = objectMapper;
+//    }
+//
+//    public <T> ReactiveRedisTemplate<String, T> getTemplate(Class<T> clazz) {
+//        return (ReactiveRedisTemplate<String, T>) templateCache.computeIfAbsent(clazz, this::createReactiveRedisTemplate);
+//    }
+//
+//    private <T> ReactiveRedisTemplate<String, T> createReactiveRedisTemplate(Class<T> clazz) {
+//        Jackson2JsonRedisSerializer<T> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, clazz);
+//        RedisSerializationContext.RedisSerializationContextBuilder<String, T> builder =
+//                RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
+//
+//        RedisSerializationContext<String, T> context = builder.value(serializer).build();
+//
+//        return new ReactiveRedisTemplate<>(factory, context);
+//    }
+//}

--- a/src/main/java/com/instream/chatSync/domain/redis/config/RedisConfig.java
+++ b/src/main/java/com/instream/chatSync/domain/redis/config/RedisConfig.java
@@ -1,0 +1,54 @@
+package com.instream.chatSync.domain.redis.config;
+
+import com.instream.chatSync.domain.redis.RedisMessageSubscriber;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+//import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String REDIS_HOST;
+
+    @Value("${spring.data.redis.port}")
+    private int REDIS_PORT;
+
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(REDIS_HOST, REDIS_PORT);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        return template;
+    }
+
+    @Bean
+    RedisMessageListenerContainer redisContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory());
+        return container;
+    }
+
+    @Bean
+    MessageListenerAdapter messageStringListener() {
+        return new MessageListenerAdapter(new RedisMessageSubscriber());
+    }
+
+//    @Bean
+//    MessageListenerAdapter messageDtoListener() {
+//        return new MessageListenerAdapter(new RedisMessageDtoSubscriber());
+//    }
+}

--- a/src/test/java/com/instream/chatSync/ChatSyncApplicationTests.java
+++ b/src/test/java/com/instream/chatSync/ChatSyncApplicationTests.java
@@ -1,0 +1,13 @@
+package com.instream.chatSync;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ChatSyncApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- [POST] sse-connect
  - sessionId를 topic으로 redis subscribe
  - 특정 sessionId를 subscribe하는 participantId 관리

<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>