### PR TITLE
<FIX> 채팅이 각 sse 별로 안 보내지는 버그 수정 

### DIFF
--- a/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
@@ -21,9 +21,8 @@ public class ChatHandler {
     public Mono<ServerResponse> getMessageList(ServerRequest request) {
         String sessionId = request.pathVariable("sessionId");
         return chatService.postConnection(sessionId)
-            .then(ServerResponse.ok()
-                .contentType(MediaType.TEXT_EVENT_STREAM)
-                .body(chatService.streamMessages(sessionId), ServerSentEvent.class)
-            );
+                .then(ServerResponse.ok()
+                        .contentType(MediaType.TEXT_EVENT_STREAM)
+                        .body(chatService.streamMessages(sessionId), ServerSentEvent.class));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,13 @@ spring:
       password: ${REDIS_PASSWORD}
   webflux:
     base-path: /api
+server:
+  port: 8081
+
+logging:
+  level:
+    org.springframework: debug
+    com.instream.chatSync: DEBUG
 ---
 tenant:
   base-url: ${TENANT_BASE_URL}


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- sse 소켓 요청시 최초 1회 레디스 구독
- sse 소켓 요청시 최초 1회 채팅 내보내는 Flux 구독
- sse 소켓 요청시 매번 sse 소켓 줌
- 채팅 내보내는 Flux에서 ConcurrentLinkedQueue 캡쳐링 기반으로 빌링, 각 세션에 존재하는 sse에 채팅 전송하는 로직 작성 

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링
- 문서 업데이트

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br/><br/>