### PR TITLE
<FEAT> 채팅 SSE 연결에 대한 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// jackson
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'

--- a/src/main/java/com/instream/chatSync/core/config/WebConfig.java
+++ b/src/main/java/com/instream/chatSync/core/config/WebConfig.java
@@ -1,5 +1,9 @@
 package com.instream.chatSync.core.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.config.CorsRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
@@ -13,5 +17,14 @@ public class WebConfig implements WebFluxConfigurer {
             .allowedMethods("*")
             .allowedHeaders("*")
             .maxAge(3600);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JavaTimeModule module = new JavaTimeModule();
+        objectMapper.registerModule(module);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
     }
 }

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/dto/ChatDto.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/dto/ChatDto.java
@@ -1,0 +1,23 @@
+package com.instream.chatSync.domain.chat.domain.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChatDto {
+    private String id;
+
+    private String nickname;
+
+    private String profileImgUrl;
+
+    private String message;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/instream/chatSync/domain/chat/domain/request/ChatBillingRequestDto.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/domain/request/ChatBillingRequestDto.java
@@ -1,4 +1,4 @@
-package com.instream.chatSync.domain.chat.domain.dto.request;
+package com.instream.chatSync.domain.chat.domain.request;
 
 import java.util.UUID;
 import lombok.Builder;

--- a/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
@@ -2,6 +2,7 @@ package com.instream.chatSync.domain.chat.handler;
 
 import com.instream.chatSync.domain.chat.service.ChatService;
 import com.instream.chatSync.domain.common.infra.helper.HandlerHelper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -13,6 +14,7 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 @Component
+@Slf4j
 public class ChatHandler {
     private final ChatService chatService;
 
@@ -22,6 +24,7 @@ public class ChatHandler {
     }
 
     public Mono<ServerResponse> getMessageList(ServerRequest request) {
+        request.pathVariables().forEach((key, value) -> log.info(key));
         Mono<UUID> sessionIdMono = HandlerHelper.getUUIDFromPathVariable(request, "sessionId");
         return sessionIdMono.flatMap(sessionId -> chatService.postConnection(sessionId)
                 .then(ServerResponse.ok()

--- a/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/handler/ChatHandler.java
@@ -1,6 +1,7 @@
 package com.instream.chatSync.domain.chat.handler;
 
 import com.instream.chatSync.domain.chat.service.ChatService;
+import com.instream.chatSync.domain.common.infra.helper.HandlerHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
+
+import java.util.UUID;
 
 @Component
 public class ChatHandler {
@@ -19,10 +22,10 @@ public class ChatHandler {
     }
 
     public Mono<ServerResponse> getMessageList(ServerRequest request) {
-        String sessionId = request.pathVariable("sessionId");
-        return chatService.postConnection(sessionId)
+        Mono<UUID> sessionIdMono = HandlerHelper.getUUIDFromPathVariable(request, "sessionId");
+        return sessionIdMono.flatMap(sessionId -> chatService.postConnection(sessionId)
                 .then(ServerResponse.ok()
                         .contentType(MediaType.TEXT_EVENT_STREAM)
-                        .body(chatService.streamMessages(sessionId), ServerSentEvent.class));
+                        .body(chatService.streamMessages(sessionId), ServerSentEvent.class)));
     }
 }

--- a/src/main/java/com/instream/chatSync/domain/chat/model/SubscriptionRegistry.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/model/SubscriptionRegistry.java
@@ -1,4 +1,4 @@
-package com.instream.chatSync.domain.chat.domain.dto;
+package com.instream.chatSync.domain.chat.model;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;

--- a/src/main/java/com/instream/chatSync/domain/chat/service/BillingService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/BillingService.java
@@ -1,6 +1,6 @@
 package com.instream.chatSync.domain.chat.service;
 
-import com.instream.chatSync.domain.chat.domain.dto.request.ChatBillingRequestDto;
+import com.instream.chatSync.domain.chat.domain.request.ChatBillingRequestDto;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
@@ -1,25 +1,25 @@
 package com.instream.chatSync.domain.chat.service;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-
 import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
-import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @Slf4j
 public class ChatService {
     private final ReactiveRedisTemplate<String, String> reactiveStringRedisTemplate;
     private final MessageStorageService messageStorageService;
-    private final ConcurrentHashMap<UUID, Disposable> subscribeSessionList = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Subscription> subscribeSessionList = new ConcurrentHashMap<>();
 
     @Autowired
     public ChatService(ReactiveRedisTemplate<String, String> reactiveStringRedisTemplate,
@@ -29,17 +29,18 @@ public class ChatService {
     }
 
     public Mono<Void> postConnection(UUID sessionId) {
-        return Mono.fromRunnable(() -> {
-            if(!subscribeSessionList.containsKey(sessionId)) {
-                log.info("Create redis connection {}", sessionId);
-                ChannelTopic topic = new ChannelTopic(sessionId.toString());
-                Disposable disposable = reactiveStringRedisTemplate.listenTo(topic)
-                    .doOnNext(message -> messageStorageService.addMessage(sessionId, message.getMessage()))
-                    .subscribe();
-                messageStorageService.addPublishFlux(sessionId);
-                subscribeSessionList.put(sessionId, disposable);
-            }
-        }).then();
+        return Mono.just(sessionId)
+                .filter(id -> !subscribeSessionList.containsKey(id))
+                .flatMap(id -> {
+                    ChannelTopic topic = new ChannelTopic(id.toString());
+                    return reactiveStringRedisTemplate.listenTo(topic)
+                            .doOnNext(message -> messageStorageService.addMessage(id, message.getMessage()))
+                            .doOnSubscribe(subscription -> {
+                                messageStorageService.addPublishFlux(id);
+                                subscribeSessionList.put(id, subscription);
+                            })
+                            .then();
+                });
     }
 
     public Flux<ServerSentEvent<List<String>>> streamMessages(UUID sessionId) {

--- a/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
@@ -23,7 +23,6 @@ public class MessageStorageService {
     private final ConcurrentHashMap<UUID, Queue<String>> messageQueues = new ConcurrentHashMap<>();
 
     private final ConcurrentHashMap<UUID, Disposable> messagePublishFluxes = new ConcurrentHashMap<>();
-
     private final ConcurrentHashMap<UUID, List<Sinks.Many<ServerSentEvent<List<String>>>>> sessionSockets = new ConcurrentHashMap<>();
 
     private final BillingService billingService;

--- a/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
@@ -1,6 +1,6 @@
 package com.instream.chatSync.domain.chat.service;
 
-import com.instream.chatSync.domain.chat.domain.dto.request.ChatBillingRequestDto;
+import com.instream.chatSync.domain.chat.domain.request.ChatBillingRequestDto;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/MessageStorageService.java
@@ -6,7 +6,6 @@ import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
 import java.time.Duration;
@@ -42,36 +41,12 @@ public class MessageStorageService {
         if (messagePublishFluxes.containsKey(sessionId)) {
             return;
         }
-        Flux<Void> flux = Flux.interval(Duration.ofSeconds(1))
-                .flatMap(tick -> {
-                    Queue<String> msgQueue = messageQueues.get(sessionId);
+        Flux<Long> flux = Flux.interval(Duration.ofSeconds(1)).doOnNext(tick -> publishMessages(sessionId));
 
-                    if (msgQueue == null || msgQueue.isEmpty()) {
-                        return Mono.empty();
-                    }
-
-                    // 임시 메세지 저장소 생성
-                    List<String> tempMessages = new ArrayList<>(msgQueue);
-
-                    // messageQueue를 비워줍니다. 채팅 편집 동시성을 높이기 위해서 원본은 사용하지 않습니다.
-                    msgQueue.clear();
-
-                    billingChat(sessionId, tempMessages);
-
-                    // sessionId 해당하는 소켓에 메시지 전송
-                    ServerSentEvent<List<String>> event = ServerSentEvent.builder(tempMessages).build();
-                    sessionSockets.getOrDefault(sessionId, new ArrayList<>())
-                            .parallelStream()
-                            .forEach(socket -> socket.tryEmitNext(event));
-
-                    // 임시 메시지 큐 메모리 해제
-                    tempMessages.clear();
-                    return Mono.empty();
-                });
-
-        log.info("Create message publisher {}", sessionId);
-
-        messagePublishFluxes.put(sessionId, flux.subscribe());
+        messagePublishFluxes.computeIfAbsent(sessionId, key -> {
+            log.info("Create message publisher {}", sessionId);
+            return flux.subscribe();
+        });
     }
 
     public Flux<ServerSentEvent<List<String>>> streamMessages(UUID sessionId) {
@@ -82,6 +57,31 @@ public class MessageStorageService {
         log.info("Create SSE {}", sessionId);
 
         return sink.asFlux();
+    }
+
+    private void publishMessages(UUID sessionId) {
+        Queue<String> msgQueue = messageQueues.get(sessionId);
+
+        if (msgQueue == null || msgQueue.isEmpty()) {
+            return;
+        }
+
+        // 임시 메세지 저장소 생성
+        List<String> tempMessages = new ArrayList<>(msgQueue);
+
+        // messageQueue를 비워줍니다. 채팅 편집 동시성을 높이기 위해서 원본은 사용하지 않습니다.
+        msgQueue.clear();
+
+        billingChat(sessionId, tempMessages);
+
+        // sessionId 해당하는 소켓에 메시지 전송
+        ServerSentEvent<List<String>> event = ServerSentEvent.builder(tempMessages).build();
+        sessionSockets.getOrDefault(sessionId, new ArrayList<>())
+                .parallelStream()
+                .forEach(socket -> socket.tryEmitNext(event));
+
+        // 임시 메시지 큐 메모리 해제
+        tempMessages.clear();
     }
 
     private void billingChat(UUID sessionId, List<String> tempMessages) {

--- a/src/main/java/com/instream/chatSync/domain/common/infra/helper/HandlerHelper.java
+++ b/src/main/java/com/instream/chatSync/domain/common/infra/helper/HandlerHelper.java
@@ -1,0 +1,19 @@
+package com.instream.chatSync.domain.common.infra.helper;
+
+import com.instream.chatSync.domain.error.infra.enums.CommonHttpErrorCode;
+import com.instream.chatSync.domain.error.model.exception.RestApiException;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+public class HandlerHelper {
+    static public Mono<UUID> getUUIDFromPathVariable(ServerRequest request, String variableName) {
+        try {
+            UUID result = UUID.fromString(request.pathVariable(variableName));
+            return Mono.just(result);
+        } catch (IllegalArgumentException illegalArgumentException) {
+            return Mono.error(new RestApiException(CommonHttpErrorCode.BAD_REQUEST));
+        }
+    }
+}

--- a/src/main/java/com/instream/chatSync/domain/error/handler/GlobalErrorWebExceptionHandler.java
+++ b/src/main/java/com/instream/chatSync/domain/error/handler/GlobalErrorWebExceptionHandler.java
@@ -3,8 +3,6 @@ package com.instream.chatSync.domain.error.handler;
 import com.instream.chatSync.domain.error.infra.enums.CommonHttpErrorCode;
 import com.instream.chatSync.domain.error.infra.enums.HttpErrorCode;
 import com.instream.chatSync.domain.error.model.exception.RestApiException;
-import java.util.Collections;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
@@ -20,6 +18,9 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
 
 @Component
 @Order(-2) // webflux default @Order(-1)

--- a/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
@@ -49,9 +49,9 @@ public class ChatRouterConfigTest {
                 ServerSentEvent.builder(new ChatDto("2", "nickname2", "profileUrl2", "메시지 2", LocalDateTime.now())).build(),
                 ServerSentEvent.builder(new ChatDto("3", "nickname3", "profileUrl3", "메시지 3", LocalDateTime.now())).build()
         );
-        Mockito.when(chatService.postConnection(sessionId.toString()))
+        Mockito.when(chatService.postConnection(sessionId))
                 .thenReturn(Mono.empty());
-        Mockito.when(chatService.streamMessages(sessionId.toString()))
+        Mockito.when(chatService.streamMessages(sessionId))
                 .thenAnswer(invocation -> Flux.fromIterable(sseMessages));
         // When
         FluxExchangeResult<String> result = webTestClient.get()
@@ -61,8 +61,10 @@ public class ChatRouterConfigTest {
                 .expectHeader().contentTypeCompatibleWith("text/event-stream")
                 .returnResult(String.class);
 
-
         // Then
+        Mockito.verify(chatService).postConnection(sessionId);
+        Mockito.verify(chatService).streamMessages(sessionId);
+
         StepVerifier.create(result.getResponseBody())
                 .expectNextMatches(jsonContainsMessage("메시지 1"))
                 .expectNextMatches(jsonContainsMessage("메시지 2"))

--- a/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
@@ -1,0 +1,85 @@
+package com.instream.chatSync.domain.chat.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.instream.chatSync.core.config.WebConfig;
+import com.instream.chatSync.domain.chat.domain.dto.ChatDto;
+import com.instream.chatSync.domain.chat.handler.ChatHandler;
+import com.instream.chatSync.domain.chat.service.ChatService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+@WebFluxTest
+@Import({WebConfig.class, ChatConfig.class, ChatHandler.class})
+@DisplayName("Chat Router Configuration Tests")
+public class ChatRouterConfigTest {
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private ChatService chatService;
+
+    @Test
+    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 받았을 때")
+    public void getSseSocketWithMessages() {
+        // Given
+        UUID sessionId = UUID.randomUUID();
+        List<ServerSentEvent<ChatDto>> sseMessages = List.of(
+                ServerSentEvent.builder(new ChatDto("1", "nickname1", "profileUrl1", "메시지 1", LocalDateTime.now())).build(),
+                ServerSentEvent.builder(new ChatDto("2", "nickname2", "profileUrl2", "메시지 2", LocalDateTime.now())).build(),
+                ServerSentEvent.builder(new ChatDto("3", "nickname3", "profileUrl3", "메시지 3", LocalDateTime.now())).build()
+        );
+        Mockito.when(chatService.postConnection(sessionId.toString()))
+                .thenReturn(Mono.empty());
+        Mockito.when(chatService.streamMessages(sessionId.toString()))
+                .thenAnswer(invocation -> Flux.fromIterable(sseMessages));
+        // When
+        FluxExchangeResult<String> result = webTestClient.get()
+                .uri("/v1/chats/sse-connect/{sessionId}", sessionId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentTypeCompatibleWith("text/event-stream")
+                .returnResult(String.class);
+
+
+        // Then
+        StepVerifier.create(result.getResponseBody())
+                .expectNextMatches(jsonContainsMessage("메시지 1"))
+                .expectNextMatches(jsonContainsMessage("메시지 2"))
+                .expectNextMatches(jsonContainsMessage("메시지 3"))
+                .thenCancel()
+                .verify();
+    }
+
+    private Predicate<String> jsonContainsMessage(String message) {
+        return json -> {
+            try {
+                ChatDto chatDto = objectMapper.readValue(json, ChatDto.class);
+                return message.equals(chatDto.getMessage());
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                return false;
+            }
+        };
+    }
+}

--- a/src/test/java/com/instream/chatSync/domain/chat/handler/ChatHandlerTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/handler/ChatHandlerTest.java
@@ -1,0 +1,91 @@
+package com.instream.chatSync.domain.chat.handler;
+
+import com.instream.chatSync.domain.chat.domain.dto.ChatDto;
+import com.instream.chatSync.domain.chat.service.ChatService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.*;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@WebFluxTest
+@Import(ChatHandler.class)
+@DisplayName("Chat Router Configuration Tests")
+public class ChatHandlerTest {
+    @Autowired
+    private ChatHandler chatHandler;
+
+    @MockBean
+    private ChatService chatService;
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    public void setUp() {
+        RouterFunction<ServerResponse> routerFunction = RouterFunctions.route(
+                RequestPredicates.GET("/v1/chats/sse-connect/{sessionId}"),
+                chatHandler::getMessageList);
+
+        this.webTestClient = WebTestClient.bindToRouterFunction(routerFunction).build();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 보냈을 때")
+    public void responseSseSocketWithMessages() {
+        // Given
+        UUID sessionId = UUID.randomUUID();
+        List<ServerSentEvent<ChatDto>> sseMessages = List.of(
+                ServerSentEvent.builder(new ChatDto("1", "nickname1", "profileUrl1", "메시지 1", LocalDateTime.now())).build(),
+                ServerSentEvent.builder(new ChatDto("2", "nickname2", "profileUrl2", "메시지 2", LocalDateTime.now())).build(),
+                ServerSentEvent.builder(new ChatDto("3", "nickname3", "profileUrl3", "메시지 3", LocalDateTime.now())).build()
+        );
+        Mockito.when(chatService.postConnection(sessionId))
+                .thenReturn(Mono.empty());
+        Mockito.when(chatService.streamMessages(sessionId))
+                .thenAnswer(invocation -> Flux.fromIterable(sseMessages));
+        // When
+        WebTestClient.ResponseSpec result = webTestClient.get()
+                .uri("/v1/chats/sse-connect/{sessionId}", sessionId)
+                .exchange();
+
+        // Then
+        Mockito.verify(chatService).postConnection(sessionId);
+        Mockito.verify(chatService).streamMessages(sessionId);
+
+        result
+                .expectStatus().isOk()
+                .expectHeader().contentType("text/event-stream;charset=UTF-8")
+                .expectBodyList(ServerSentEvent.class)
+                .hasSize(3);
+    }
+
+    @Test
+    @DisplayName("WebTestClient를 사용하지 않고 테스트를 진행하려고 하면 PathVariable 파싱이 안되는 에러가 발생")
+    public void throwIllegalArgumentExceptionWhenNotUsingWebTestClient() {
+        // Given
+        UUID sessionId = UUID.randomUUID();
+        MockServerHttpRequest mockRequest = MockServerHttpRequest.get("/v1/chats/sse-connect/" + sessionId)
+                .build();
+        ServerWebExchange mockExchange = MockServerWebExchange.from(mockRequest);
+        ServerRequest serverRequest = ServerRequest.create(mockExchange, HandlerStrategies.withDefaults().messageReaders());
+
+        assertThrows(IllegalArgumentException.class, () -> serverRequest.pathVariable("sessionId"));
+    }
+}

--- a/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
@@ -103,7 +103,7 @@ public class ChatServiceTest {
 
     @DisplayName("postConnection 메서드는 각 SessionId로 Redis 구독을 이미 했다면 새로운 Redis 구독을 하지 않는다.")
     @Timeout(10)
-    @RepeatedTest(10000)
+    @RepeatedTest(value = 10000, name = "Custom name {currentRepetition}/{totalRepetitions}")
     @Execution(ExecutionMode.CONCURRENT)
     public void testPostConnectionTwiceButSubscribeOnlyOneWhenConcurrent() {
         // given

--- a/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,75 @@
+package com.instream.chatSync.domain.chat.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@WebFluxTest(ChatService.class)
+public class ChatServiceTest {
+
+    @MockBean
+    private ReactiveRedisTemplate<String, String> reactiveStringRedisTemplate;
+
+    @MockBean
+    private MessageStorageService messageStorageService;
+
+    @Autowired
+    private ChatService chatService;
+
+    @Test
+    @DisplayName("postConnection 메서드는 새로운 Redis 구독을 생성해야 한다")
+    public void testPostConnection() {
+        // given
+        UUID sessionId = UUID.randomUUID();
+        ChannelTopic topic = new ChannelTopic(sessionId.toString());
+        ReactiveSubscription.Message<String, String> mockMessage = mock(ReactiveSubscription.Message.class);
+
+        // when
+        Mockito.when(mockMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(any(ChannelTopic.class))).thenAnswer(invocation -> Flux.just(mockMessage));
+        Mockito.when(messageStorageService.addMessage(any(UUID.class), anyString())).thenReturn(Mono.empty());
+        Mockito.when(messageStorageService.addPublishFlux(any(UUID.class))).thenReturn(Mono.empty());
+
+        // then
+        StepVerifier.create(chatService.postConnection(sessionId))
+                .verifyComplete();
+
+        ConcurrentHashMap<UUID, Disposable> subscribeSessionList = (ConcurrentHashMap<UUID, Disposable>) getField(chatService, "subscribeSessionList");
+        assertTrue(subscribeSessionList.containsKey(sessionId));
+
+        verify(reactiveStringRedisTemplate).listenTo(topic);
+        verify(messageStorageService).addMessage(any(UUID.class), anyString());
+        verify(messageStorageService).addPublishFlux(sessionId);
+    }
+
+
+    private Object getField(Object obj, String fieldName) {
+        try {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.get(obj);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/service/ChatServiceTest.java
@@ -1,32 +1,28 @@
 package com.instream.chatSync.domain.chat.service;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
+import org.reactivestreams.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.connection.ReactiveSubscription;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
-import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @WebFluxTest(ChatService.class)
 public class ChatServiceTest {
@@ -40,17 +36,41 @@ public class ChatServiceTest {
     @Autowired
     private ChatService chatService;
 
+    private UUID sessionId = UUID.randomUUID();
+
+    private ChannelTopic chatMessageTopic;
+
+    private ChannelTopic closeTopic;
+
+    private ConcurrentHashMap<UUID, Subscription> subscribeSessionList;
+
+    private ConcurrentHashMap<UUID, Subscription> endSessionList;
+
+    @BeforeEach
+    public void setUp() {
+        chatMessageTopic = new ChannelTopic(sessionId.toString());
+        closeTopic = new ChannelTopic(sessionId + "_END");
+        subscribeSessionList = (ConcurrentHashMap<UUID, Subscription>) getField(chatService, "subscribeSessionList");
+        endSessionList = (ConcurrentHashMap<UUID, Subscription>) getField(chatService, "endSessionList");
+
+        subscribeSessionList.clear();
+        endSessionList.clear();
+    }
+
     @Test
-    @DisplayName("postConnection 메서드는 새로운 Redis 구독을 생성해야 한다")
-    public void testPostConnection() {
+    @DisplayName("postConnection 메서드는 sessionId, sessionId_END에 대해 각각 구독을 1개씩 생성해야 한다.")
+    public void testPostConnectionWhenSubscribe() {
         // given
-        UUID sessionId = UUID.randomUUID();
-        ChannelTopic topic = new ChannelTopic(sessionId.toString());
-        ReactiveSubscription.Message<String, String> mockMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockChatMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockCloseMessage = mock(ReactiveSubscription.Message.class);
 
         // when
-        Mockito.when(mockMessage.getMessage()).thenReturn("testMessage");
-        Mockito.when(reactiveStringRedisTemplate.listenTo(any(ChannelTopic.class))).thenAnswer(invocation -> Flux.just(mockMessage));
+        Mockito.when(mockChatMessage.getChannel()).thenReturn(chatMessageTopic.getTopic());
+        Mockito.when(mockChatMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(mockCloseMessage.getChannel()).thenReturn(closeTopic.getTopic());
+        Mockito.when(mockCloseMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(chatMessageTopic)).thenAnswer(invocation -> Flux.just(mockChatMessage));
+        Mockito.when(reactiveStringRedisTemplate.listenTo(closeTopic)).thenAnswer(invocation -> Flux.empty());
         Mockito.doNothing().when(messageStorageService).addMessage(any(UUID.class), anyString());
         Mockito.doNothing().when(messageStorageService).addPublishFlux(any(UUID.class));
 
@@ -58,82 +78,155 @@ public class ChatServiceTest {
         StepVerifier.create(chatService.postConnection(sessionId))
                 .verifyComplete();
 
-        ConcurrentHashMap<UUID, Disposable> subscribeSessionList = (ConcurrentHashMap<UUID, Disposable>) getField(chatService, "subscribeSessionList");
         assertTrue(subscribeSessionList.containsKey(sessionId));
+        assertTrue(endSessionList.containsKey(sessionId));
 
-        verify(reactiveStringRedisTemplate).listenTo(topic);
-        verify(messageStorageService).addMessage(any(UUID.class), anyString());
-        verify(messageStorageService).addPublishFlux(sessionId);
+        verifyThreadSafeResult(sessionId, chatMessageTopic, closeTopic);
+    }
+
+    @Test
+    @DisplayName("postConnection 메서드는 sessionId, sessionId_END에 대해 각각 구독을 1개씩 생성하고, 1초 이후 구독을 해제할 수 있어야 한다.")
+    public void testPostConnectionWhenDisposeAfterSubscribe() throws InterruptedException {
+        // given
+        ReactiveSubscription.Message<String, String> mockChatMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockCloseMessage = mock(ReactiveSubscription.Message.class);
+
+        // when
+        Mockito.when(mockChatMessage.getChannel()).thenReturn(chatMessageTopic.getTopic());
+        Mockito.when(mockChatMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(mockCloseMessage.getChannel()).thenReturn(closeTopic.getTopic());
+        Mockito.when(mockCloseMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(chatMessageTopic)).thenAnswer(invocation -> Flux.just(mockChatMessage));
+        Mockito.when(reactiveStringRedisTemplate.listenTo(closeTopic)).thenAnswer(invocation -> Flux.just(mockCloseMessage).delayElements(Duration.ofSeconds(1)));
+        Mockito.doNothing().when(messageStorageService).addMessage(any(UUID.class), anyString());
+        Mockito.doNothing().when(messageStorageService).addPublishFlux(any(UUID.class));
+
+        // then
+        StepVerifier.create(chatService.postConnection(sessionId))
+                .verifyComplete();
+
+        Thread.sleep(2000);
+
+        assertFalse(subscribeSessionList.containsKey(sessionId));
+        assertFalse(endSessionList.containsKey(sessionId));
+
+        verifyThreadSafeResult(sessionId, chatMessageTopic, closeTopic);
+    }
+
+    @Test
+    @DisplayName("postConnection 메서드는 sessionId, sessionId_END에 대해 구독 생성과 구독 해제 메세지가 동시에 도착했을 때도 오류가 없어야 한다.")
+    public void testPostConnectionGetMessagesConcurrent() {
+        // given
+        ReactiveSubscription.Message<String, String> mockChatMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockCloseMessage = mock(ReactiveSubscription.Message.class);
+
+        // when
+        Mockito.when(mockChatMessage.getChannel()).thenReturn(chatMessageTopic.getTopic());
+        Mockito.when(mockChatMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(mockCloseMessage.getChannel()).thenReturn(closeTopic.getTopic());
+        Mockito.when(mockCloseMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(chatMessageTopic)).thenAnswer(invocation -> Flux.just(mockChatMessage));
+        Mockito.when(reactiveStringRedisTemplate.listenTo(closeTopic)).thenAnswer(invocation -> Flux.just(mockCloseMessage));
+        Mockito.doNothing().when(messageStorageService).addMessage(any(UUID.class), anyString());
+        Mockito.doNothing().when(messageStorageService).addPublishFlux(any(UUID.class));
+
+        // then
+        StepVerifier.create(chatService.postConnection(sessionId))
+                .verifyComplete();
+
+        assertFalse(subscribeSessionList.containsKey(sessionId));
+        assertFalse(endSessionList.containsKey(sessionId));
+
+        verifyThreadSafeResult(sessionId, chatMessageTopic, closeTopic);
     }
 
     @Test
     @DisplayName("postConnection 메서드는 각 SessionId로 Redis 구독을 이미 했다면 새로운 Redis 구독을 하지 않는다.")
     public void testPostConnectionTwiceButSubscribeOnlyOne() {
         // given
-        UUID sessionId = UUID.randomUUID();
-        ChannelTopic topic = new ChannelTopic(sessionId.toString());
-        ReactiveSubscription.Message<String, String> mockMessage = mock(ReactiveSubscription.Message.class);
-        ConcurrentHashMap<UUID, Disposable> subscribeSessionList = (ConcurrentHashMap<UUID, Disposable>) getField(chatService, "subscribeSessionList");
+        ReactiveSubscription.Message<String, String> mockChatMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockCloseMessage = mock(ReactiveSubscription.Message.class);
+        Subscription chatMessageSubscription;
+        Subscription closeSubscription;
 
         // when
-        Mockito.when(mockMessage.getMessage()).thenReturn("testMessage");
-        Mockito.when(reactiveStringRedisTemplate.listenTo(any(ChannelTopic.class))).thenAnswer(invocation -> Flux.just(mockMessage));
+        Mockito.when(mockChatMessage.getChannel()).thenReturn(chatMessageTopic.getTopic());
+        Mockito.when(mockChatMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(mockCloseMessage.getChannel()).thenReturn(closeTopic.getTopic());
+        Mockito.when(mockCloseMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(chatMessageTopic)).thenAnswer(invocation -> Flux.just(mockChatMessage));
+        Mockito.when(reactiveStringRedisTemplate.listenTo(closeTopic)).thenAnswer(invocation -> Flux.empty());
         Mockito.doNothing().when(messageStorageService).addMessage(any(UUID.class), anyString());
         Mockito.doNothing().when(messageStorageService).addPublishFlux(any(UUID.class));
 
 
         // then
+        // 한 sessionId에 대해 1회 구독
         StepVerifier.create(chatService.postConnection(sessionId))
                 .verifyComplete();
 
         assertTrue(subscribeSessionList.containsKey(sessionId));
+        assertTrue(endSessionList.containsKey(sessionId));
 
-        Disposable subscription = subscribeSessionList.get(sessionId);
+        chatMessageSubscription = subscribeSessionList.get(sessionId);
+        closeSubscription = endSessionList.get(sessionId);
+
+        // 한 sessionId에 대해 2회 구독 시도
         StepVerifier.create(chatService.postConnection(sessionId))
                 .verifyComplete();
 
         assertTrue(subscribeSessionList.containsKey(sessionId));
-        assertEquals(subscribeSessionList.get(sessionId), subscription);
+        assertTrue(endSessionList.containsKey(sessionId));
 
-        verify(reactiveStringRedisTemplate).listenTo(topic);
-        verify(messageStorageService).addMessage(any(UUID.class), anyString());
-        verify(messageStorageService).addPublishFlux(sessionId);
+        assertEquals(subscribeSessionList.get(sessionId), chatMessageSubscription);
+        assertEquals(endSessionList.get(sessionId), closeSubscription);
+
+        verifyThreadSafeResult(sessionId, chatMessageTopic, closeTopic);
     }
 
     @DisplayName("Multi-threading 환경에서도 postConnection 메서드는 각 SessionId로 Redis 구독을 이미 했다면 새로운 Redis 구독을 하지 않는다.")
     @Timeout(10)
     @RepeatedTest(value = 1000, name = "Thread {currentRepetition}/{totalRepetitions}")
     @Execution(ExecutionMode.CONCURRENT)
-    public void testPostConnectionTwiceButSubscribeOnlyOneWhenConcurrent() {
+    public void testPostConnectionIsSafeWhenConcurrent() {
         // given
-        UUID sessionId = UUID.randomUUID();
-        ChannelTopic topic = new ChannelTopic(sessionId.toString());
-        ReactiveSubscription.Message<String, String> mockMessage = mock(ReactiveSubscription.Message.class);
-        ConcurrentHashMap<UUID, Disposable> subscribeSessionList = (ConcurrentHashMap<UUID, Disposable>) getField(chatService, "subscribeSessionList");
+        ReactiveSubscription.Message<String, String> mockChatMessage = mock(ReactiveSubscription.Message.class);
+        ReactiveSubscription.Message<String, String> mockCloseMessage = mock(ReactiveSubscription.Message.class);
+        Subscription chatMessageSubscription;
+        Subscription closeSubscription;
 
         // when
-        Mockito.when(mockMessage.getMessage()).thenReturn("testMessage");
-        Mockito.when(reactiveStringRedisTemplate.listenTo(any(ChannelTopic.class))).thenAnswer(invocation -> Flux.just(mockMessage));
+        Mockito.when(mockChatMessage.getChannel()).thenReturn(chatMessageTopic.getTopic());
+        Mockito.when(mockChatMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(mockCloseMessage.getChannel()).thenReturn(closeTopic.getTopic());
+        Mockito.when(mockCloseMessage.getMessage()).thenReturn("testMessage");
+        Mockito.when(reactiveStringRedisTemplate.listenTo(chatMessageTopic)).thenAnswer(invocation -> Flux.just(mockChatMessage));
+        Mockito.when(reactiveStringRedisTemplate.listenTo(closeTopic)).thenAnswer(invocation -> Flux.empty());
         Mockito.doNothing().when(messageStorageService).addMessage(any(UUID.class), anyString());
         Mockito.doNothing().when(messageStorageService).addPublishFlux(any(UUID.class));
 
-
         // then
+        // 한 sessionId에 대해 1회 구독
         StepVerifier.create(chatService.postConnection(sessionId))
                 .verifyComplete();
 
         assertTrue(subscribeSessionList.containsKey(sessionId));
+        assertTrue(endSessionList.containsKey(sessionId));
 
-        Disposable disposable = subscribeSessionList.get(sessionId);
+        chatMessageSubscription = subscribeSessionList.get(sessionId);
+        closeSubscription = endSessionList.get(sessionId);
+
+        // 한 sessionId에 대해 2회 구독 시도
         StepVerifier.create(chatService.postConnection(sessionId))
                 .verifyComplete();
 
         assertTrue(subscribeSessionList.containsKey(sessionId));
-        assertEquals(subscribeSessionList.get(sessionId), disposable);
+        assertTrue(endSessionList.containsKey(sessionId));
 
-        verify(reactiveStringRedisTemplate).listenTo(topic);
-        verify(messageStorageService).addMessage(any(UUID.class), anyString());
-        verify(messageStorageService).addPublishFlux(sessionId);
+        assertEquals(subscribeSessionList.get(sessionId), chatMessageSubscription);
+        assertEquals(endSessionList.get(sessionId), closeSubscription);
+
+        verifyThreadSafeResult(sessionId, chatMessageTopic, closeTopic);
     }
 
     private Object getField(Object obj, String fieldName) {
@@ -144,5 +237,12 @@ public class ChatServiceTest {
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void verifyThreadSafeResult(UUID sessionId, ChannelTopic chatMessageTopic, ChannelTopic closeTopic) {
+        verify(reactiveStringRedisTemplate).listenTo(chatMessageTopic);
+        verify(reactiveStringRedisTemplate).listenTo(closeTopic);
+        verify(messageStorageService).addMessage(any(UUID.class), anyString());
+        verify(messageStorageService).addPublishFlux(sessionId);
     }
 }

--- a/src/test/java/com/instream/chatSync/domain/chat/service/MessageStorageServiceTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/service/MessageStorageServiceTest.java
@@ -1,0 +1,14 @@
+package com.instream.chatSync.domain.chat.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@WebFluxTest(MessageStorageServiceTest.class)
+public class MessageStorageServiceTest {
+    @Autowired
+    private MessageStorageService messageStorageService;
+
+    @MockBean
+    private BillingService billingService;
+}


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- ChatRouterConfig에 대한 Test 추가
  - SSE 연결 API 호출하고 채팅 메세지 전파받는 시나리오 검증 
- ChatHandler에 대한 Test 추가
  - SSE 연결 API 호출하고 채팅 메세지 전파받는 시나리오 검증 
  - 테스트 시나리오에서 RouterConfig에 대한 의존성을 제거하기 위해 WebTestClient를 사용하지 않으면, 테스트 진행 불가능하다는 시나리오 검증
- ChatService에 대한 Test 추가
  - postConnection 함수를 호출하면 chatMessage, close topic을 1회만 구독하는 시나리오 검증
  - Multi-threading 환경에서도 postConnection가 안전하게 topic을 1회만 구독하는 시나리오 검증

<br/>

### 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링
- 문서 업데이트

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- Multi-threading 환경에서 postConnection 함수가 안전하지 않아서 수정했습니다.
- Redis 구독 / 구독 해제는 synchronized bloc으로 동기화 시켰습니다. race condition 상황에서도 thread-safe 하도록 했습니다.

<br/><br/>