### PR TITLE
<FIX> publishMessages 로직에서 msgQueue.clear를 호출할 때 채팅 메세지가 사라질 위험 제거

### DIFF
--- a/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
+++ b/src/main/java/com/instream/chatSync/domain/chat/service/ChatService.java
@@ -22,7 +22,6 @@ public class ChatService {
     private final ConcurrentHashMap<UUID, Subscription> subscribeSessionList = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, Subscription> endSessionList = new ConcurrentHashMap<>();
 
-
     @Autowired
     public ChatService(ReactiveRedisTemplate<String, String> reactiveStringRedisTemplate,
                        MessageStorageService messageStorageService) {
@@ -96,6 +95,8 @@ public class ChatService {
         if (endSessionList.containsKey(endSessionId)) {
             endSessionList.remove(endSessionId).cancel();
         }
+
+        messageStorageService.closePublishFlux(endSessionId);
     }
 }
 

--- a/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/config/ChatRouterConfigTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.web.reactive.server.FluxExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
@@ -28,7 +27,7 @@ import java.util.function.Predicate;
 
 @WebFluxTest
 @Import({WebConfig.class, ChatConfig.class, ChatHandler.class})
-@DisplayName("Chat Router Configuration Tests")
+@DisplayName("ChatRouterConfig Tests")
 public class ChatRouterConfigTest {
     @Autowired
     private ObjectMapper objectMapper;
@@ -40,7 +39,7 @@ public class ChatRouterConfigTest {
     private ChatService chatService;
 
     @Test
-    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 받았을 때")
+    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 받았을 때, SSE 소켓을 올바르게 받고 3개의 채팅 메세지를 받을 수 있어야 한다.")
     public void getSseSocketWithMessages() {
         // Given
         UUID sessionId = UUID.randomUUID();

--- a/src/test/java/com/instream/chatSync/domain/chat/handler/ChatHandlerTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/handler/ChatHandlerTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @WebFluxTest
 @Import(ChatHandler.class)
-@DisplayName("Chat Router Configuration Tests")
+@DisplayName("ChatHandler Tests")
 public class ChatHandlerTest {
     @Autowired
     private ChatHandler chatHandler;
@@ -47,7 +47,7 @@ public class ChatHandlerTest {
     }
 
     @Test
-    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 보냈을 때")
+    @DisplayName("GET /api/v1/chats/sse-connect/{sessionId} 호출하고 3개의 채팅 메세지를 보냈을 때, SSE 소켓을 올바르게 받고 3개의 채팅 메세지를 받을 수 있어야 한다.")
     public void responseSseSocketWithMessages() {
         // Given
         UUID sessionId = UUID.randomUUID();
@@ -77,7 +77,7 @@ public class ChatHandlerTest {
     }
 
     @Test
-    @DisplayName("WebTestClient를 사용하지 않고 테스트를 진행하려고 하면 PathVariable 파싱이 안되는 에러가 발생")
+    @DisplayName("WebTestClient를 사용하지 않고 테스트를 진행하려고 하면 PathVariable 파싱이 안되는 에러가 발생한다.")
     public void throwIllegalArgumentExceptionWhenNotUsingWebTestClient() {
         // Given
         UUID sessionId = UUID.randomUUID();

--- a/src/test/java/com/instream/chatSync/domain/chat/service/MessageStorageServiceTest.java
+++ b/src/test/java/com/instream/chatSync/domain/chat/service/MessageStorageServiceTest.java
@@ -1,14 +1,60 @@
 package com.instream.chatSync.domain.chat.service;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@WebFluxTest(MessageStorageServiceTest.class)
+import java.util.UUID;
+
+@WebFluxTest(MessageStorageService.class)
 public class MessageStorageServiceTest {
     @Autowired
     private MessageStorageService messageStorageService;
 
     @MockBean
     private BillingService billingService;
+
+    private UUID sessionId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("addMessage 메서드는 각 세션 별로 최초 1회 호출 때만 ConcurrentLinkedQueue를 생성한다.")
+    public void createMessageQueueOnlyOnceWhenCallAddMessage() {}
+
+    @Timeout(10)
+    @RepeatedTest(value = 500, name = "Thread {currentRepetition}/{totalRepetitions}")
+    @Execution(ExecutionMode.CONCURRENT)
+    @DisplayName("addMessage 메서드는 Multi-Threading 상황에서도 메세지를 안정적으로 저장한다.")
+    public void saveMessageWhenMultiThreading() {}
+
+    @Test
+    @DisplayName("addPublishFlux 메서드는 n ms마다 메세지를 전파하는 로직을 각 세션마다 1회 구독한다.")
+    public void subscribeOnlyOnceWhenCallAddPublishFlux() {}
+
+    @Test
+    @DisplayName("addPublishFlux 메서드는 n ms마다 메세지를 전파하는 로직을 실행할 때 Billing API를 호출한다.")
+    public void callBillingAPIWhenPublishMessage() {}
+
+    @Test
+    @DisplayName("addPublishFlux 메서드는 n ms마다 메세지를 전파하는 로직을 실행할 때, 2개의 SSE 소켓에 똑같은 메세지를 전파한다.")
+    public void publishSameMessageToSocketsWhenPublishMessage() {}
+
+    @Test
+    @DisplayName("addPublishFlux 메서드는 n ms마다 메세지를 전파하는 로직을 실행하고 나서 다음 전파 시간 전까지, 메세지 큐에는 이전 전파 메세지는 없고 다음 전파 메세지만이 남아있어야 한다.")
+    public void existsOnlyNextPublishMessageInMessageQueue() {}
+
+    @Timeout(10)
+    @RepeatedTest(value = 500, name = "Thread {currentRepetition}/{totalRepetitions}")
+    @Execution(ExecutionMode.CONCURRENT)
+    @DisplayName("closePublishFlux 메서드는 Multi-Threading 상황에서도 구독 해제가 정상적으로 된다.")
+    public void disposeFluxWhenCallClosePublishFlux() {}
+
+    @Test
+    @DisplayName("streamMessages 메서드는 각 세션 별로 최초 1회 호출때만 SSE 소켓 저장 리스트를 생성한다.")
+    public void createSSEStoreListOnlyOnceWhenCallStreamMessages() {}
 }


### PR DESCRIPTION
### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

- msgQueue.clear 대신 message length 만큼 poll 하는 것으로 변경
- 동기적으로 짜여있던 billing API, chat broadcasting 로직을 Reactive하게 변경

<br/>

### 📘 작업 유형

- 버그 수정
- 리펙토링
- 문서 업데이트

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 동시 상황에서 publishMessages 로직 중 message 목록을 deep copy 한 이후, msgQueue.clear를 호출하는 사이 시간에 채팅 메세지가 사라질 위험이 있었습니다.
- 동기적으로 짜여있던 billing API, chat broadcasting 로직을 Mono.when을 활용해서 동시에 처리되도록 했습니다.

<br/><br/>